### PR TITLE
[35기 전은형] ADD : SubCategoryView, ProductView 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,7 @@ zsdoc/data
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm,vim,zsh,visualstudiocode,macos,linux
 
 my_settings.py
+
+# DB 정보 숨기기
+db_uploaders.py
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -404,4 +404,4 @@ my_settings.py
 
 # DB 정보 숨기기
 db_uploaders.py
-*.csv
+csv

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from products.views import SubCategoryView
+
+urlpatterns = [
+    path('/subcategories', SubCategoryView.as_view())
+    
+]

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,9 +1,8 @@
 from django.urls import path
+
 from products.views import ProductView, SubCategoryView
 
 urlpatterns = [
     path('', ProductView.as_view()),
     path('/subcategories', SubCategoryView.as_view()),
-    
-    
 ]

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
-from products.views import SubCategoryView
+from products.views import ProductView, SubCategoryView
 
 urlpatterns = [
-    path('/subcategories', SubCategoryView.as_view())
+    path('', ProductView.as_view()),
+    path('/subcategories', SubCategoryView.as_view()),
+    
     
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -1,3 +1,23 @@
-from django.shortcuts import render
+from django.http  import JsonResponse
+from django.views import View
+
+from products.models import SubCategory
 
 # Create your views here.
+class SubCategoryView(View):
+    def get(self, request):
+        subcategories = SubCategory.objects.all()
+        result        = []
+        
+        for subcategory in subcategories:
+            result.append({
+                'id'         : subcategory.id,
+                'name'       : subcategory.name,
+                'image_url'  : subcategory.image_url,
+                'category_id': subcategory.category_id,
+            })
+        
+        return JsonResponse({'message':result}, status=200)
+        
+        
+    

--- a/products/views.py
+++ b/products/views.py
@@ -1,7 +1,7 @@
 from django.http  import JsonResponse
 from django.views import View
 
-from products.models import SubCategory
+from products.models import SubCategory, Product
 
 # Create your views here.
 class SubCategoryView(View):
@@ -19,5 +19,20 @@ class SubCategoryView(View):
         
         return JsonResponse({'message':result}, status=200)
         
+
+class ProductView(View):
+    def get(self, request):
+        products = Product.objects.all()
+        result   = []
         
-    
+        for product in products:
+            result.append({
+                'id'             : product.id,
+                'name'           : product.name,
+                'number'         : product.number,
+                'description'    : product.description,
+                'image_url'      : product.image_url,
+                'sub_category_id': product.sub_category_id
+            })
+        
+        return JsonResponse({'message':result}, status=200)

--- a/zara/urls.py
+++ b/zara/urls.py
@@ -17,4 +17,5 @@ Including another URLconf
 from django.urls import path, include
 
 urlpatterns = [
+    path('products', include('products.urls'))
 ]


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- CSV파일 작성 후 DB에 저장하기
- SubCategoryView : 서브 카테고리 조회 기능(GET)
- ProductView : 전체 상품 조회 기능(GET)

<br />

## :: 구현 사항 설명
1. CSV
- products > models.py안에 있는 클래스에 해당하는 CSV파일 모두 생성 및 DB에 적용
- 생성한 CSV파일들은 폴더로 관리하고, DB가 노출되지 않도록 .gitignore에 추가함

2. 서브 카테고리 조회 기능
- DB에 저장된 서브 카테고리 목록 조회

3. 전체 상품 조회 기능
- DB에 저장된 전체 상품 목록 조회

<br />

## :: 성장 포인트 
1. CSV
- 테이블 당 CSV파일을 각각 만들어야 모델링 시 만들었던 데이터 규격에 맞는 데이터를 집어넣을 수 있습니다. 
- 데이터는 외부에 노출되면 안되는 정보기에 .gitignore에 추가해야합니다.

2. 서브 카테고리 및 상품 조회 기능
- DB에 저장된 데이터들을 보여줍니다.

3. 깃허브 브랜치
- feature/add_products에서 CSV파일 DB에 저장 및 서브카테고리 조회, 전체 상품 조회 기능을 작업했습니다.
- 기능별 브랜치를 나눠야 한다는 점을 망각하고 있었습니다. 앞으로는 기능별로 브랜치를 나누도록 하겠습니다.

<br />

## :: 기타 질문 및 특이 사항
- 하나의 CSV파일에 모든 데이터를 작성하여 데이터를 집어넣을 수도 있을까요?
- 서브카테고리와 전체 상품 조회 뷰에는 POST 메소드를 구현하지 않았습니다. CSV파일에 있는 데이터들만 DB에 저장되었다 판단되어서 try, except문을 사용하여 에러 핸들링을 하지 않았는데 이와 별개로 이예외처리를 해줘야하는 걸까요?
- 전체상품조회에 대한 엔드포인트는 /products로 구현했습니다. 서브 카테고리를 조회하는 기능도 products app 안에서 작성했기 때문에 엔드포인트가 /products/subcategories 가 됩니다. 자라홈은 엔드포인트가 /서브카테고리로 구현이 되어있습니다.(대카테고리/소카테고리/상품 순) 이런 경우에는 products app이 아니라 categories app을 만들고 그 안에서 상품 관련 뷰를 작성했어야하는 걸까요?