### PR TITLE
[35기 전은형] ADD : ProductDetailView 

### DIFF
--- a/products/urls.py
+++ b/products/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from products.views import ProductDetailView
+
+urlpatterns = [
+    path("/<int:product_id>", ProductDetailView.as_view())
+]

--- a/products/views.py
+++ b/products/views.py
@@ -27,24 +27,17 @@ class ProductDetailView(View):
         try:
             product = Product.objects.get(id=product_id)   
             options = product.productoption_set.filter(product_id = product.id)  
-
-            option_list = []
-
-            for option in options:
-                option_list.append({
-                    'size' : option.size.name,   
-                    'price' : option.price
-                })
-
-            result = {
-                'id'             : product.id,
-                'name'           : product.name,
-                'number'         : product.number,
-                'description'    : product.description,
-                'image_url'      : product.image_url,
-                'sub_category_id': product.sub_category_id,
-                'options'        : option_list,
-            }
+            
+            result = { 'id'              : product.id,
+                        'name'           : product.name,
+                        'number'         : product.number,
+                        'description'    : product.description,
+                        'image_url'      : product.image_url,
+                        'sub_category_id': product.sub_category_id,
+                        'options'        : [{ 'size':option.size.name,
+                                             'price':option.price } for option in options]}
+            
+            return JsonResponse({'result':result}, status=200)
             
         except Product.DoesNotExist:
             return JsonResponse({'message':'Product does not exist.'}, status=404)

--- a/products/views.py
+++ b/products/views.py
@@ -1,7 +1,7 @@
 from django.http  import JsonResponse
 from django.views import View
 
-from products.models import SubCategory
+from products.models import Product, ProductOption, SubCategory
 
 # Create your views here.
 
@@ -23,3 +23,33 @@ class SubCategoryView(View):
             })
         
         return JsonResponse({'message':result}, status=200)
+    
+class ProductDetailView(View):
+    def get(self, request, product_id):
+        
+        try:
+            product = Product.objects.get(id=product_id)   
+            options = product.productoption_set.filter(product_id = product.id)  
+            
+            option_list = []
+            
+            for option in options:
+                option_list.append({
+                    'size' : option.size.name,   
+                    'price' : option.price
+                })
+            
+            result = {
+                'id'             : product.id,
+                'name'           : product.name,
+                'number'         : product.number,
+                'description'    : product.description,
+                'image_url'      : product.image_url,
+                'sub_category_id': product.sub_category_id,
+                'options'        : option_list,
+            }
+            
+            return JsonResponse({'message':result}, status=200)
+            
+        except Product.DoesNotExist:
+            return JsonResponse({'message':'Product does not exist.'}, status=400)

--- a/products/views.py
+++ b/products/views.py
@@ -47,4 +47,4 @@ class ProductDetailView(View):
             }
             
         except Product.DoesNotExist:
-            return JsonResponse({'message':'Product does not exist.'}, status=400)
+            return JsonResponse({'message':'Product does not exist.'}, status=404)

--- a/products/views.py
+++ b/products/views.py
@@ -26,7 +26,7 @@ class ProductDetailView(View):
 
         try:
             product = Product.objects.get(id=product_id)   
-            options = product.productoption_set.filter(product_id = product.id)  
+            options = product.productoption_set.all()  
                 
             result = { 
                 'id'             : product.id,

--- a/products/views.py
+++ b/products/views.py
@@ -27,15 +27,19 @@ class ProductDetailView(View):
         try:
             product = Product.objects.get(id=product_id)   
             options = product.productoption_set.filter(product_id = product.id)  
-            
-            result = { 'id'              : product.id,
-                        'name'           : product.name,
-                        'number'         : product.number,
-                        'description'    : product.description,
-                        'image_url'      : product.image_url,
-                        'sub_category_id': product.sub_category_id,
-                        'options'        : [{ 'size':option.size.name,
-                                             'price':option.price } for option in options]}
+                
+            result = { 
+                'id'             : product.id,
+                'name'           : product.name,
+                'number'         : product.number,
+                'description'    : product.description,
+                'image_url'      : product.image_url,
+                'sub_category_id': product.sub_category_id,
+                'options'        : [{ 
+                    'size'  : option.size.name,
+                    'price' : option.price 
+                } for option in options]
+            }
             
             return JsonResponse({'result':result}, status=200)
             

--- a/products/views.py
+++ b/products/views.py
@@ -1,7 +1,7 @@
 from django.http  import JsonResponse
 from django.views import View
 
-from products.models import Product, ProductOption, SubCategory
+from products.models import Product, SubCategory
 
 # Create your views here.
 

--- a/products/views.py
+++ b/products/views.py
@@ -21,3 +21,30 @@ class SubCategoryView(View):
         
         return JsonResponse({'result':result}, status=200)    
      
+class ProductDetailView(View):
+    def get(self, request, product_id):
+
+        try:
+            product = Product.objects.get(id=product_id)   
+            options = product.productoption_set.filter(product_id = product.id)  
+
+            option_list = []
+
+            for option in options:
+                option_list.append({
+                    'size' : option.size.name,   
+                    'price' : option.price
+                })
+
+            result = {
+                'id'             : product.id,
+                'name'           : product.name,
+                'number'         : product.number,
+                'description'    : product.description,
+                'image_url'      : product.image_url,
+                'sub_category_id': product.sub_category_id,
+                'options'        : option_list,
+            }
+            
+        except Product.DoesNotExist:
+            return JsonResponse({'message':'Product does not exist.'}, status=400)

--- a/zara/urls.py
+++ b/zara/urls.py
@@ -20,5 +20,6 @@ from products.views import SubCategoryView
 
 urlpatterns = [
     path("users", include("users.urls")),
-    path("categories/<int:category_id>/subcategories", SubCategoryView.as_view())
+    path("categories/<int:category_id>/subcategories", SubCategoryView.as_view()),
+    path("products", include("products.urls"))
 ]


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 상품 상세페이지 뷰 API 생성

<br />

## :: 구현 사항 설명
1. 엔드포인트 설정
- /products/<int:product_id> 주소로 들어오면, ProductDetailView로 연결됩니다.

<br />

2. 상품 상세페이지 뷰
- 클라이언트로부터 product_id를 전달받습니다.
- 먼저 Product객체들 중에서 상품id가 일치하는 객체를 가져옵니다.
- get을 사용했기 때문에 상품id가 존재하지 않는 경우 에러를 일으킵니다.
- Product.DoesNotExist 에러 핸들링은 메세지는 'Product does not exist.'로, 코드는 400으로 처리합니다.

<br />

- Product 컬럼에는 price가 없기 때문에 ProductOption의 price가 필요합니다.
- ProductOption에는 size_id값만 있기 때문에 Size의 name이 필요합니다.
- ProductOption에는 product가 FK로 연결되어 있기 때문에 productoption_set을 사용하여 역참조가 가능합니다. 이를 사용해서 ProductOption 객체들 중에서 상품id가 일치하는 객체들을 filter를 사용하여 쿼리셋으로 가져옵니다. 
- 쿼리셋은 리스트에 담아서 사용해야하기 때문에 반복문을 돌며 필요한 key와 value값을 넣어줍니다.
- Size역시 ProductOption에 FK로 연결되어 있어서 Size의 이름을 가져올 수 있습니다.

<br />

- 상품 상세정보를 보여줄 때 사이즈마다 가격이 다르므로 이에 대한 옵션정보를 리스트에 담아 반환합니다.

<br />

## :: 성장 포인트 
- 특정 자원에 대한 정보를 가져올 때는 path parameter를 사용합니다.
- Product안에는 size가 없고, size가 있는 ProductOption안에는 size name이 없어서 사이즈별 가격을 상품과 연결할 때 많이 힘들었습니다. 
- FK로 연결을 하면 연결된 테이블의 컬럼에 '.'을 사용하여 접근이 가능하고, _set을 사용하면 역참조가 가능하다는 점을 리마인드하게된 계기가 되었습니다.
- 데이터 구조를 잘 파악하여 ERD를 작성하고, ERD를 토대로 모델링을 작성해야지 ORM을 활발하게 사용할 수 있다는 것을 깨달았습니다.

<br />

## :: 기타 질문 및 특이 사항
- 처리해야하는 예외사항이 더 있을까요?
